### PR TITLE
Update KubeDescheduler to recognize and evict VM pods

### DIFF
--- a/manifests/descheduler-operator-cr.yaml
+++ b/manifests/descheduler-operator-cr.yaml
@@ -9,5 +9,8 @@ spec:
   deschedulingIntervalSeconds: 360
   profiles:
   - LongLifecycle
+  - EvictPodsWithPVC
+  - EvictPodsWithLocalStorage
   profileCustomizations:
+    devEnableEvictionsInBackground: true
     devActualUtilizationProfile: PrometheusCPUPSIPressure


### PR DESCRIPTION
SSIA