### PR TITLE
Add on-cluster COO deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,168 @@ Two dashboards are available for monitoring the descheduler behaviour.
 A Grafana dashboard for the PSI-based load-aware rebalancing profile.
 See [monitoring/README.md](monitoring/README.md) for deployment instructions.
 
+### Memory Aware Rebalancing (Perses — on-cluster via COO)
+
+The dashboard can be deployed directly onto the cluster using the
+[Cluster Observability Operator](https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/)
+(COO) `PersesDashboard` CRD.  This makes it available inside the OpenShift
+Console under **Observe → Dashboards**.
+
+**Prerequisites:** COO ≥ v1.3 installed (Perses CRDs present), `jq`.
+
+#### Step 1 — Enable Perses in the COO UIPlugin
+
+If no `UIPlugin` exists yet, create one:
+
+```console
+$ oc apply -f - <<'EOF'
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: monitoring
+spec:
+  type: Monitoring
+  monitoring:
+    perses:
+      enabled: true
+EOF
+```
+
+If a `monitoring` UIPlugin already exists (e.g. created by another component),
+patch it instead:
+
+```console
+$ oc patch uiplugins.observability.openshift.io monitoring \
+    --type=merge \
+    -p '{"spec":{"monitoring":{"perses":{"enabled":true}}}}'
+```
+
+Wait until the Perses server is up:
+
+```console
+$ oc rollout status statefulset/perses \
+    -n openshift-cluster-observability-operator
+```
+
+#### Step 2 — Create a namespace and grant Thanos access
+
+```console
+$ oc new-project descheduler-monitoring
+
+$ oc create serviceaccount perses-datasource-sa -n descheduler-monitoring
+
+$ oc adm policy add-cluster-role-to-user cluster-monitoring-view \
+    -z perses-datasource-sa -n descheduler-monitoring
+```
+
+#### Step 3 — Create the bearer-token secret
+
+```console
+$ oc create secret generic thanos-querier-datasource-secret \
+    -n descheduler-monitoring \
+    --from-literal=token="$(
+        oc create token perses-datasource-sa \
+            -n descheduler-monitoring \
+            --duration=8760h
+    )"
+```
+
+> [!NOTE]
+> `oc create token` issues a short-lived token bounded to the ServiceAccount.
+> Rotate it by re-running Step 3 **and** Step 5 below.
+
+#### Step 4 — Create the PersesDatasource
+
+```console
+$ oc apply -f - <<'EOF'
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: thanos-querier
+  namespace: descheduler-monitoring
+spec:
+  config:
+    default: true
+    display:
+      name: Thanos Querier
+    plugin:
+      kind: PrometheusDatasource
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+            secret: thanos-querier-datasource-secret
+  client:
+    tls:
+      enable: true
+      caCert:
+        type: file
+        certPath: /ca/service-ca.crt
+EOF
+```
+
+#### Step 5 — Register the bearer token with the Perses server
+
+The `perses-operator` reconciles the `PersesDatasource` CR into the Perses
+server's internal file database, but it only stores the TLS configuration there.
+The bearer token must be pushed directly to the Perses API so that the server
+can attach it to outgoing Thanos requests.
+
+```console
+$ oc port-forward -n openshift-cluster-observability-operator \
+    svc/perses 18443:8080 &
+$ PF_PID=$!
+
+$ OC_TOKEN=$(oc whoami -t)
+$ BEARER=$(oc get secret thanos-querier-datasource-secret \
+    -n descheduler-monitoring \
+    -o jsonpath='{.data.token}' | base64 -d)
+
+$ curl -sk -X POST \
+    -H "Authorization: Bearer $OC_TOKEN" \
+    -H "Content-Type: application/json" \
+    https://localhost:18443/api/v1/projects/descheduler-monitoring/secrets \
+    -d "{
+      \"kind\": \"Secret\",
+      \"metadata\": {
+        \"name\": \"thanos-querier-datasource-secret\",
+        \"project\": \"descheduler-monitoring\"
+      },
+      \"spec\": {
+        \"authorization\": {\"type\": \"Bearer\", \"credentials\": \"$BEARER\"},
+        \"tlsConfig\": {\"caFile\": \"/ca/service-ca.crt\"}
+      }
+    }"
+
+$ kill $PF_PID
+```
+
+> [!NOTE]
+> The Perses server stores its database on a PersistentVolumeClaim, so this
+> secret survives pod restarts.  Re-run this step whenever the bearer token is
+> rotated (Step 3).
+
+#### Step 6 — Deploy the dashboard
+
+```console
+$ jq '{
+    apiVersion: "perses.dev/v1alpha1",
+    kind: "PersesDashboard",
+    metadata: {
+      name: "memory-aware-rebalancing",
+      namespace: "descheduler-monitoring"
+    },
+    spec: .spec
+  }' monitoring/perses/provisioning/memory_aware_rebalancing.json \
+  | oc apply -f -
+```
+
+The dashboard appears in the OpenShift Console under
+**Observe → Dashboards → memory-aware-rebalancing** within a few seconds.
+
+To update the dashboard after editing the provisioning JSON, re-run Step 6.
+
 ### Memory Aware Rebalancing (Perses — local)
 
 A [Perses](https://perses.dev) dashboard focused on the memory-aware aspects:
@@ -90,7 +252,7 @@ to the target cluster.
 
 ```console
 $ cd monitoring/perses
-$ KUBECONFIG=/path/to/kubeconfig ./start.sh
+$ KUBECONFIG=/path/to/kubeconfig ./start.sh start
 ```
 
 Open **http://localhost:8080** and navigate to
@@ -102,7 +264,7 @@ To stop the stack:
 $ ./start.sh stop
 ```
 
-To refresh an expired token (tokens are short-lived), simply re-run `./start.sh` —
+To refresh an expired token (tokens are short-lived), simply re-run `./start.sh start` —
 it regenerates `nginx.conf` with the new token and restarts the proxy container.
 
 #### What the dashboard shows

--- a/monitoring/perses/provisioning/memory_aware_rebalancing.json
+++ b/monitoring/perses/provisioning/memory_aware_rebalancing.json
@@ -10,20 +10,24 @@
   "spec": {
     "duration": "1h",
     "refreshInterval": "1m",
-
     "variables": [
       {
         "kind": "ListVariable",
         "spec": {
           "name": "node",
-          "display": {"name": "Node", "hidden": false},
+          "display": {
+            "name": "Node",
+            "hidden": false
+          },
           "allowMultiple": true,
           "allowAllValue": true,
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
               "labelName": "instance",
-              "matchers": ["descheduler:nodeutilization:cpu:avg1m"]
+              "matchers": [
+                "descheduler:nodeutilization:cpu:avg1m"
+              ]
             }
           }
         }
@@ -32,39 +36,53 @@
         "kind": "ListVariable",
         "spec": {
           "name": "limit",
-          "display": {"name": "Max evictions shown", "hidden": false},
+          "display": {
+            "name": "Max evictions shown",
+            "hidden": false
+          },
           "allowMultiple": false,
           "allowAllValue": false,
           "defaultValue": "15",
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
-              "values": ["10", "15", "20"]
+              "values": [
+                "10",
+                "15",
+                "20"
+              ]
             }
           }
         }
       }
     ],
-
     "panels": {
-
       "cpuUtilByNode": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "CPU Utilization — per Node",
-            "description": "CPU utilization over time for each node. The red ★ avg workers series is the fleet average — nodes far from it are candidates for rebalancing."
+            "name": "CPU Utilization \u2014 per Node",
+            "description": "CPU utilization over time for each node. The red \u2605 avg workers series is the fleet average \u2014 nodes far from it are candidates for rebalancing."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": {"position": "right", "mode": "list"},
+              "legend": {
+                "position": "right",
+                "mode": "list"
+              },
               "yAxis": {
                 "label": "CPU Utilization",
-                "format": {"unit": "percent-decimal"},
+                "format": {
+                  "unit": "percent-decimal"
+                },
                 "min": 0
               },
-              "visual": {"display": "line", "lineWidth": 1, "areaOpacity": 0.05},
+              "visual": {
+                "display": "line",
+                "lineWidth": 1,
+                "areaOpacity": 0.05
+              },
               "querySettings": [
                 {
                   "queryIndex": 1,
@@ -94,7 +112,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "descheduler:averageworkersutilization:cpu:avg1m{}",
-                    "seriesNameFormat": "★ avg workers"
+                    "seriesNameFormat": "\u2605 avg workers"
                   }
                 }
               }
@@ -102,24 +120,32 @@
           ]
         }
       },
-
       "memUtilByNode": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Memory Utilization — per Node",
-            "description": "Memory utilization over time for each node. The red ★ avg workers series is the fleet average — nodes far from it are candidates for rebalancing."
+            "name": "Memory Utilization \u2014 per Node",
+            "description": "Memory utilization over time for each node. The red \u2605 avg workers series is the fleet average \u2014 nodes far from it are candidates for rebalancing."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": {"position": "right", "mode": "list"},
+              "legend": {
+                "position": "right",
+                "mode": "list"
+              },
               "yAxis": {
                 "label": "Memory Utilization",
-                "format": {"unit": "percent-decimal"},
+                "format": {
+                  "unit": "percent-decimal"
+                },
                 "min": 0
               },
-              "visual": {"display": "line", "lineWidth": 1, "areaOpacity": 0.05},
+              "visual": {
+                "display": "line",
+                "lineWidth": 1,
+                "areaOpacity": 0.05
+              },
               "querySettings": [
                 {
                   "queryIndex": 1,
@@ -149,7 +175,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "descheduler:averageworkersutilization:memory:avg1m{}",
-                    "seriesNameFormat": "★ avg workers"
+                    "seriesNameFormat": "\u2605 avg workers"
                   }
                 }
               }
@@ -157,24 +183,32 @@
           ]
         }
       },
-
       "cpuPressureByNode": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "CPU Pressure (PSI) — per Node",
-            "description": "CPU PSI pressure over time per node. Near-zero under normal conditions. The red ★ avg workers is the fleet average."
+            "name": "CPU Pressure (PSI) \u2014 per Node",
+            "description": "CPU PSI pressure over time per node. Near-zero under normal conditions. The red \u2605 avg workers is the fleet average."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": {"position": "right", "mode": "list"},
+              "legend": {
+                "position": "right",
+                "mode": "list"
+              },
               "yAxis": {
                 "label": "CPU Pressure",
-                "format": {"unit": "percent-decimal"},
+                "format": {
+                  "unit": "percent-decimal"
+                },
                 "min": 0
               },
-              "visual": {"display": "line", "lineWidth": 1, "areaOpacity": 0.05},
+              "visual": {
+                "display": "line",
+                "lineWidth": 1,
+                "areaOpacity": 0.05
+              },
               "querySettings": [
                 {
                   "queryIndex": 1,
@@ -204,7 +238,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "descheduler:averageworkerspressure:cpu:avg1m{}",
-                    "seriesNameFormat": "★ avg workers"
+                    "seriesNameFormat": "\u2605 avg workers"
                   }
                 }
               }
@@ -212,24 +246,32 @@
           ]
         }
       },
-
       "memPressureByNode": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Memory Pressure (PSI) — per Node",
-            "description": "Memory PSI pressure over time per node. Near-zero under normal conditions. The red ★ avg workers is the fleet average."
+            "name": "Memory Pressure (PSI) \u2014 per Node",
+            "description": "Memory PSI pressure over time per node. Near-zero under normal conditions. The red \u2605 avg workers is the fleet average."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": {"position": "right", "mode": "list"},
+              "legend": {
+                "position": "right",
+                "mode": "list"
+              },
               "yAxis": {
                 "label": "Memory Pressure",
-                "format": {"unit": "percent-decimal"},
+                "format": {
+                  "unit": "percent-decimal"
+                },
                 "min": 0
               },
-              "visual": {"display": "line", "lineWidth": 1, "areaOpacity": 0.05},
+              "visual": {
+                "display": "line",
+                "lineWidth": 1,
+                "areaOpacity": 0.05
+              },
               "querySettings": [
                 {
                   "queryIndex": 1,
@@ -259,7 +301,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "descheduler:averageworkerspressure:memory:avg1m{}",
-                    "seriesNameFormat": "★ avg workers"
+                    "seriesNameFormat": "\u2605 avg workers"
                   }
                 }
               }
@@ -267,7 +309,6 @@
           ]
         }
       },
-
       "utilizationValues": {
         "kind": "Panel",
         "spec": {
@@ -278,25 +319,35 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": {"position": "right", "mode": "table", "values": ["last"]},
+              "legend": {
+                "position": "right",
+                "mode": "table",
+                "values": [
+                  "last"
+                ]
+              },
               "yAxis": {
                 "label": "Utilization Value",
-                "format": {"unit": "percent-decimal"},
+                "format": {
+                  "unit": "percent-decimal"
+                },
                 "min": 0
               },
-              "visual": {"display": "line", "lineWidth": 1, "areaOpacity": 0.05},
+              "visual": {
+                "display": "line",
+                "lineWidth": 1,
+                "areaOpacity": 0.05
+              },
               "querySettings": [
                 {
                   "queryIndex": 1,
                   "colorMode": "fixed-single",
-                  "colorValue": "#f2495c",
-                  "lineStyle": "dashed"
+                  "colorValue": "#f2495c"
                 },
                 {
                   "queryIndex": 2,
                   "colorMode": "fixed-single",
-                  "colorValue": "#ff9830",
-                  "lineStyle": "dashed"
+                  "colorValue": "#ff9830"
                 }
               ]
             }
@@ -341,7 +392,6 @@
           ]
         }
       },
-
       "nodeClassification": {
         "kind": "Panel",
         "spec": {
@@ -352,27 +402,38 @@
           "plugin": {
             "kind": "StatusHistoryChart",
             "spec": {
-              "legend": {"position": "bottom"},
+              "legend": {
+                "position": "bottom"
+              },
               "mappings": [
                 {
                   "kind": "Value",
                   "spec": {
                     "value": "0",
-                    "result": {"value": "Underutilized", "color": "#5794f2"}
+                    "result": {
+                      "value": "Underutilized",
+                      "color": "#5794f2"
+                    }
                   }
                 },
                 {
                   "kind": "Value",
                   "spec": {
                     "value": "1",
-                    "result": {"value": "Normal", "color": "#73bf69"}
+                    "result": {
+                      "value": "Normal",
+                      "color": "#73bf69"
+                    }
                   }
                 },
                 {
                   "kind": "Value",
                   "spec": {
                     "value": "2",
-                    "result": {"value": "Overutilized", "color": "#f2495c"}
+                    "result": {
+                      "value": "Overutilized",
+                      "color": "#f2495c"
+                    }
                   }
                 }
               ]
@@ -394,7 +455,6 @@
           ]
         }
       },
-
       "totalEvictions": {
         "kind": "Panel",
         "spec": {
@@ -406,7 +466,10 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "format": {"unit": "decimal", "decimalPlaces": 0}
+              "format": {
+                "unit": "decimal",
+                "decimalPlaces": 0
+              }
             }
           },
           "queries": [
@@ -425,24 +488,36 @@
           ]
         }
       },
-
       "evictionsRate": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Evictions (KubeVirtRelieveAndMigrate) — per Node, rolling 5 min",
+            "name": "Evictions (KubeVirtRelieveAndMigrate) \u2014 per Node, rolling 5 min",
             "description": "Number of successful evictions in the trailing 5-minute window per node. A single eviction event appears as 1 for ~5 minutes then drops back to 0."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": {"position": "right", "mode": "table", "values": ["last"]},
+              "legend": {
+                "position": "right",
+                "mode": "table",
+                "values": [
+                  "last"
+                ]
+              },
               "yAxis": {
                 "label": "Evictions (last 5 min)",
-                "format": {"unit": "decimal", "decimalPlaces": 0},
+                "format": {
+                  "unit": "decimal",
+                  "decimalPlaces": 0
+                },
                 "min": 0
               },
-              "visual": {"display": "line", "lineWidth": 2, "areaOpacity": 0.4}
+              "visual": {
+                "display": "line",
+                "lineWidth": 2,
+                "areaOpacity": 0.4
+              }
             }
           },
           "queries": [
@@ -461,24 +536,90 @@
           ]
         }
       },
-
       "evictionHistory": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Recent Evictions — by Node & Namespace",
-            "description": "Top $limit most recent evictions, one row per (node, namespace) pair, sorted by last eviction time. Timestamps are derived from when the descheduler_pods_evicted counter last changed — accuracy is within the scrape interval (~1–2 min). The 6 h lookback is relative to the end of the selected time window, not to wall-clock now."
+            "name": "Recent Evictions \u2014 by Node & Namespace",
+            "description": "$limit (node, namespace) pairs with the most recent eviction in the trailing 6 hours, sorted by recency (smallest = most recent). \"Last eviction\" shows how long ago the last eviction was detected, measured from now. Lookback is fixed at 6 h from the end of the selected time window."
           },
           "plugin": {
             "kind": "Table",
             "spec": {
               "density": "compact",
-              "defaultColumnHidden": true,
               "columnSettings": [
-                {"name": "node",               "header": "Node",         "enableSorting": true, "hide": false},
-                {"name": "exported_namespace", "header": "Namespace",    "enableSorting": true, "hide": false},
-                {"name": "value",              "header": "Last evicted", "enableSorting": true, "hide": false, "sort": "desc", "align": "right",
-                  "format": {"unit": "datetime-local"}}
+                {
+                  "name": "node",
+                  "header": "Node",
+                  "enableSorting": true
+                },
+                {
+                  "name": "exported_namespace",
+                  "header": "Namespace",
+                  "enableSorting": true
+                },
+                {
+                  "name": "value",
+                  "header": "Last eviction",
+                  "enableSorting": true,
+                  "sort": "asc",
+                  "align": "right",
+                  "format": {
+                    "unit": "seconds"
+                  }
+                },
+                {
+                  "name": "timestamp",
+                  "hide": true
+                },
+                {
+                  "name": "endpoint",
+                  "hide": true
+                },
+                {
+                  "name": "instance",
+                  "hide": true
+                },
+                {
+                  "name": "job",
+                  "hide": true
+                },
+                {
+                  "name": "managed_cluster",
+                  "hide": true
+                },
+                {
+                  "name": "namespace",
+                  "hide": true
+                },
+                {
+                  "name": "pod",
+                  "hide": true
+                },
+                {
+                  "name": "pod_namespace",
+                  "hide": true
+                },
+                {
+                  "name": "profile",
+                  "hide": true
+                },
+                {
+                  "name": "prometheus",
+                  "hide": true
+                },
+                {
+                  "name": "result",
+                  "hide": true
+                },
+                {
+                  "name": "service",
+                  "hide": true
+                },
+                {
+                  "name": "strategy",
+                  "hide": true
+                }
               ]
             }
           },
@@ -489,7 +630,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "topk($limit, max_over_time(timestamp(delta(descheduler_pods_evicted{profile=\"KubeVirtRelieveAndMigrate\", result=\"success\", node=~\"$node\"}[2m]) > 0)[6h:2m]))"
+                    "query": "bottomk($limit, time() - (max_over_time((time() * (delta(descheduler_pods_evicted{profile=\"KubeVirtRelieveAndMigrate\", result=\"success\", node=~\"$node\"}[5m]) >= bool 1))[6h:1m]) > 0))"
                   }
                 }
               }
@@ -497,24 +638,36 @@
           ]
         }
       },
-
       "evictionsTimeSeries": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Pods Evicted (KubeVirtRelieveAndMigrate) — per Node",
+            "name": "Pods Evicted (KubeVirtRelieveAndMigrate) \u2014 per Node",
             "description": "Cumulative successful evictions over time broken down by source node."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": {"position": "right", "mode": "table", "values": ["last"]},
+              "legend": {
+                "position": "right",
+                "mode": "table",
+                "values": [
+                  "last"
+                ]
+              },
               "yAxis": {
                 "label": "Evicted Pods",
-                "format": {"unit": "decimal", "decimalPlaces": 0},
+                "format": {
+                  "unit": "decimal",
+                  "decimalPlaces": 0
+                },
                 "min": 0
               },
-              "visual": {"display": "line", "lineWidth": 2, "areaOpacity": 0.1}
+              "visual": {
+                "display": "line",
+                "lineWidth": 2,
+                "areaOpacity": 0.1
+              }
             }
           },
           "queries": [
@@ -533,20 +686,36 @@
           ]
         }
       }
-
     },
-
     "layouts": [
       {
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "Utilization — CPU & Memory per Node",
-            "collapse": {"open": true}
+            "title": "Utilization \u2014 CPU & Memory per Node",
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            {"x": 0,  "y": 0, "width": 12, "height": 10, "content": {"$ref": "#/spec/panels/cpuUtilByNode"}},
-            {"x": 12, "y": 0, "width": 12, "height": 10, "content": {"$ref": "#/spec/panels/memUtilByNode"}}
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/cpuUtilByNode"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/memUtilByNode"
+              }
+            }
           ]
         }
       },
@@ -554,12 +723,30 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "Pressure (PSI) — CPU & Memory per Node",
-            "collapse": {"open": true}
+            "title": "Pressure (PSI) \u2014 CPU & Memory per Node",
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            {"x": 0,  "y": 0, "width": 12, "height": 10, "content": {"$ref": "#/spec/panels/cpuPressureByNode"}},
-            {"x": 12, "y": 0, "width": 12, "height": 10, "content": {"$ref": "#/spec/panels/memPressureByNode"}}
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/cpuPressureByNode"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/memPressureByNode"
+              }
+            }
           ]
         }
       },
@@ -568,10 +755,20 @@
         "spec": {
           "display": {
             "title": "Synthetic Utilization Value & Dynamic Thresholds",
-            "collapse": {"open": true}
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            {"x": 0, "y": 0, "width": 24, "height": 10, "content": {"$ref": "#/spec/panels/utilizationValues"}}
+            {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/utilizationValues"
+              }
+            }
           ]
         }
       },
@@ -580,10 +777,20 @@
         "spec": {
           "display": {
             "title": "Node Classification over Time",
-            "collapse": {"open": true}
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            {"x": 0, "y": 0, "width": 24, "height": 10, "content": {"$ref": "#/spec/panels/nodeClassification"}}
+            {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/nodeClassification"
+              }
+            }
           ]
         }
       },
@@ -592,16 +799,50 @@
         "spec": {
           "display": {
             "title": "Evictions",
-            "collapse": {"open": true}
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            {"x": 0,  "y": 0, "width":  4, "height":  4, "content": {"$ref": "#/spec/panels/totalEvictions"}},
-            {"x": 4,  "y": 0, "width": 20, "height":  8, "content": {"$ref": "#/spec/panels/evictionsTimeSeries"}},
-            {"x": 0,  "y": 8, "width": 24, "height":  8, "content": {"$ref": "#/spec/panels/evictionsRate"}},
-            {"x": 0,  "y": 16, "width": 24, "height": 10, "content": {"$ref": "#/spec/panels/evictionHistory"}}
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/totalEvictions"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 20,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/evictionsTimeSeries"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/evictionsRate"
+              }
+            },
+            {
+              "x": 0,
+              "y": 16,
+              "width": 24,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/evictionHistory"
+              }
+            }
           ]
         }
-      },
+      }
     ]
   }
 }

--- a/monitoring/perses/start.sh
+++ b/monitoring/perses/start.sh
@@ -2,13 +2,19 @@
 # Starts a local Perses instance wired to the remote Thanos querier.
 #
 # Usage:
-#   ./start.sh                         # uses KUBECONFIG env var
+#   ./start.sh [start]                 # uses KUBECONFIG env var
 #   ./start.sh /path/to/kubeconfig     # uses the given kubeconfig
 #   ./start.sh stop                    # stops the stack
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# "start" is an accepted no-op keyword so callers can be explicit
+if [[ "${1:-}" == "start" ]]; then
+  shift
+fi
+
 KUBECONFIG="${1:-${KUBECONFIG:-}}"
 
 if [[ "${1:-}" == "stop" ]]; then
@@ -72,5 +78,5 @@ echo ""
 echo "Perses is starting at http://localhost:8080"
 echo "Dashboard: http://localhost:8080/projects/descheduler/dashboards/memory-aware-rebalancing"
 echo ""
-echo "To stop: $0 stop"
-echo "To refresh the token: $0 ${KUBECONFIG}"
+echo "To stop:          $0 stop"
+echo "To refresh token: $0 start"


### PR DESCRIPTION
- Add 'Memory Aware Rebalancing (Perses — on-cluster via COO)' section to README with step-by-step instructions: UIPlugin creation/patch, namespace setup, ServiceAccount + cluster-monitoring-view RBAC, bearer-token Secret, PersesDatasource, and jq-based PersesDashboard generation from the provisioning JSON. Steps verified against a fresh COO v1.3.1 cluster.
- Fix dashboard compatibility with COO v1.3.1 / Perses Table-0.7.0 (Switch eviction history panel to time-ago display)